### PR TITLE
Account Abstraction Support

### DIFF
--- a/packages/core/src/types/wallet.ts
+++ b/packages/core/src/types/wallet.ts
@@ -15,6 +15,7 @@ import { SignClientTypes } from '@walletconnect/types';
 import { ChainWalletBase, MainWalletBase } from '../bases';
 import { ChainName, ChainRecord } from './chain';
 import { DappEnv, Mutable, OS, SignType } from './common';
+import { Tx } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
 
 export interface Key {
   readonly name: string;
@@ -221,6 +222,13 @@ export interface WalletClient {
     tx: Uint8Array,
     mode: BroadcastMode
   ) => Promise<Uint8Array>;
+  signAATx?: (
+    chainID: string,
+    accountAddress: Bech32Address,
+    accountNumber: number,
+    sequence: number,
+    unsignedTx: Uint8Array
+  ) => Promise<Tx>;
 }
 
 export type WalletAdapter = ChainWalletBase | MainWalletBase;

--- a/wallets/keplr-extension/src/extension/utils.ts
+++ b/wallets/keplr-extension/src/extension/utils.ts
@@ -1,5 +1,11 @@
 import { ClientNotExistError } from '@cosmos-kit/core';
 import { Keplr, Window as KeplrWindow } from '@keplr-wallet/types';
+import bech32 from 'bech32';
+
+export function addressBytesFromBech32(str) {
+  const { words } = bech32.decode(str);
+  return bech32.fromWords(words);
+}
 
 export const getKeplrFromExtension: () => Promise<
   Keplr | undefined


### PR DESCRIPTION
This is a pass at adding AA support with Keplr, a well supported cosmos and cosmos-kit wallet. This is based on the Metamask example by 0xLarry at https://github.com/larry0x/metamask-cosmos-demo/blob/main/src/index.js